### PR TITLE
Add CLI and optimizer tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ warn_return_any = true
 warn_unreachable = true
 
 [tool.pytest.ini_options]
+addopts = "-vv"
 testpaths = ["tests"]
 python_files = "test_*.py"
 python_functions = "test_*"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,10 @@
+from click.testing import CliRunner
+from prompt_optimizer.cli import main
+
+
+def test_cli_help():
+    runner = CliRunner()
+    result = runner.invoke(main, ["--help"])
+    assert result.exit_code == 0
+    # Help message should contain usage information
+    assert "Usage" in result.output or "Show this message" in result.output

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+import pytest
+
+import prompt_optimizer.optimizer as optimizer
+
+
+@pytest.fixture
+def mock_dspy(monkeypatch):
+    class FakePredict:
+        def __init__(self, signature):
+            self.signature = signature
+
+        def __call__(self, **kwargs):
+            return SimpleNamespace(improved_prompt="improved", analysis="analysis")
+
+    class FakeChainOfThought(FakePredict):
+        def update_demos(self, demos):
+            # No-op for demo update
+            pass
+
+        def __call__(self, **kwargs):
+            return SimpleNamespace(
+                improved_prompt="improved",
+                analysis="analysis",
+                total_score="10",
+                feedback="feedback",
+                clarity_score="10",
+                specificity_score="10",
+                actionability_score="10",
+            )
+
+    fake_dspy = SimpleNamespace(
+        Signature=object,
+        InputField=lambda *a, **kw: None,
+        OutputField=lambda *a, **kw: None,
+        Predict=FakePredict,
+        ChainOfThought=FakeChainOfThought,
+        Example=lambda *a, **kw: SimpleNamespace(),
+        settings=SimpleNamespace(configure=lambda **kw: None),
+        LM=lambda **kw: None,
+    )
+
+    monkeypatch.setattr(optimizer, "dspy", fake_dspy)
+
+
+def test_self_refinement_optimizer(mock_dspy):
+    opt = optimizer.SelfRefinementOptimizer(model="m", api_key="k")
+    result = opt.optimize("prompt")
+    assert result == "improved"
+
+
+def test_example_based_optimizer(mock_dspy):
+    opt = optimizer.ExampleBasedOptimizer(model="m", api_key="k")
+    result = opt.optimize("prompt")
+    assert result == "improved"
+
+
+def test_metric_based_optimizer(mock_dspy):
+    opt = optimizer.MetricBasedOptimizer(model="m", api_key="k")
+    result = opt.optimize("prompt")
+    assert result == "improved"


### PR DESCRIPTION
## Summary
- add test_cli.py with basic Click runner check
- cover optimizers with mocked dspy components
- configure pytest to show verbose output

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*

## Summary by Sourcery

Add CLI and optimizer tests and configure pytest for verbose output

Build:
- Enable verbose pytest output by adding addopts "-vv" to pytest configuration

Tests:
- Add test for CLI help command using Click runner
- Add tests for SelfRefinementOptimizer, ExampleBasedOptimizer, and MetricBasedOptimizer with mocked dspy components