### PR TITLE
Improve DSPy setup docstring

### DIFF
--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -1,5 +1,6 @@
 """Minimal runtime stub for the DSPy library used in tests."""
 
+
 class Signature:
     """Base class for DSPy signatures."""
 
@@ -36,7 +37,8 @@ class Example:
     """Placeholder for Example."""
 
     def __init__(self, *args: object, **kwargs: object) -> None:
-        pass
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
 
 class LM:

--- a/prompt_optimizer/optimizer/base.py
+++ b/prompt_optimizer/optimizer/base.py
@@ -2,8 +2,8 @@
 Base class for prompt optimization strategies.
 """
 
-from dataclasses import dataclass, field
 import logging
+from dataclasses import dataclass, field
 from typing import Final
 
 import dspy
@@ -33,7 +33,23 @@ class PromptOptimizer:
         self._setup_dspy()
 
     def _setup_dspy(self) -> None:
-        """Set up DSPy with the Anthropic model."""
+        """Configure DSPy for use with the Anthropic model.
+
+        This method instantiates :class:`dspy.LM` using ``self.model`` and
+        ``self.api_key``. The resulting language model is stored on
+        ``self.lm`` and registered as the default via :func:`dspy.configure`.
+        When ``self.verbose`` is ``True`` a log message noting the chosen
+        model and ``max_tokens`` is emitted.
+
+        Args:
+            None: All configuration values are read from the instance
+                attributes.
+
+        Raises:
+            ValueError: If ``api_key`` is empty.
+            RuntimeError: If the language model cannot be created or DSPy
+                configuration fails.
+        """
         # Configure the LM using Anthropic with custom max_tokens
         self.lm = dspy.LM(
             self.model,


### PR DESCRIPTION
## Summary
- document `_setup_dspy` in detail
- add basic attribute storage to the `Example` stub so tests can run

## Testing
- `poetry run pyright --project pyrightconfig.strict.json .`
- `poetry run mypy .`
- `poetry run black .`
- `PYTHONPATH=$(pwd) pytest -q`